### PR TITLE
Use classifiers to specify the license.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,6 @@ setup(
     url='https://github.com/armbrustlab/seaflowpy',
     author='Chris T. Berthiaume',
     author_email='chrisbee@uw.edu',
-    license='GPL3',
     packages=find_packages(where='src'),
     package_dir={'': 'src'},
     include_package_data=True,
@@ -26,5 +25,8 @@ setup(
             'seaflowpy=seaflowpy.cli.cli:cli'
         ]
     },
+    classifiers=[
+        'License :: OSI Approved :: GNU General Public License v3 (GPLv3)'
+    ],
     zip_safe=True
 )


### PR DESCRIPTION
Classifiers are a standard way of specifying a license, and make it easy
for automated tools to properly detect the license of the package.

The "license" field should only be used if the license has no
corresponding Trove classifier.